### PR TITLE
Add method to enable ssh logins w/ password

### DIFF
--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -34,6 +34,12 @@ class JumpCloud
     send_to_server(system_data)
   end
 
+  def self.set_sshPassEnabled()
+    system_data = get_system_data()
+    system_data["allowSshPasswordAuthentication"] = true
+    send_to_server(system_data)
+  end
+
   def self.delete_system()
     date = get_date
     system_key = get_key_from_config


### PR DESCRIPTION
I have a large user base that still use passwords for authentication rather than keys and unfortunately I need this setting enabled.  I have a highly elastic environment and the recent changes to the SSL ciphers resulted in a bunch of EC2 instances being spun up that many people could not ssh into with their passwords.  I had been using puppet to add this snippet directly into the gem, but I assumed version 0.2.0 rather than the new version you just published.  

If you could add this method so I can strip it from my puppet stuff, it would be greatly appreciated it.

Thanks

Ryan
