### PR TITLE
Adding class constructor and instance method to support single POST operation

### DIFF
--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -4,6 +4,22 @@ require 'openssl'
 require 'net/http'
 
 class JumpCloud
+  
+  attr_accessor :settings
+  
+  def initialize(args=self.class.get_system_data())
+    @settings = args
+  end
+  
+  def update_settings(options)
+    data = {}
+    data.merge!(@settings) 
+    options.each do |k,v|
+      data[k] = v if @settings.has_key?(k) 
+    end
+    JumpCloud.send_to_server(data)
+  end
+  
   def self.get_date
     Time.now.utc.strftime("+%a, %d %h %Y %H:%M:%S GMT")
   end


### PR DESCRIPTION
Please consider these changes after review.  

The reason for this pull request is there are currently no defined class methods that allow a system to modify/set all changes with a single API post.  These changes will allow a user initialize an instance of JumpCloud that auto loads the current default settings of the particular server using the class method get_system_data().  Then using an instance method of that object, I can set all settings with one single method call.  

The final usage would look like this: 

jc = JumpCloud.new()

jc.update_settings({
    "displayName" => "Foo-Server",
    "allowSshPasswordAuthentication" => true,
    "allowPublicKeyAuthentication" => true,
    "allowSshRootLogin" => false,
    "tags" => ['dev']
    })

The gem will still support the class methods if users still want to use the legacy class set methods (i.e. set_system_tags()).  During my testing, I found these changes have greatly improved success rates of setting the desired configs.  Using the existing published gem, we were relying on 3 separate API calls to configure our server every time we spun a new one up.  This change would collapse that down to a single call; helping reduce overall load on your API.

One thing I am not considering with these additions is allowed keys that are actually adjustable.  The new update_settings(options) exposes the full json returned from get_system_data().  I imagine only a tiny subset of that data is actually modifiable from a client perspective.  One thing that can be done within the method would be to define what are those acceptable keys, but I am of the opinion that the API should handle input validation and good documentation can inform the user which keys are acceptable to use.  

Please feel free to contact me at  ryan.bachman@inin.com if you have any questions.  Thanks for reviewing and the consideration.  
