### PR TITLE
Addressing issue #3 and some TLC

### DIFF
--- a/jumpcloud.gemspec
+++ b/jumpcloud.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'jumpcloud'
-  s.version     = '0.4.0'
+  s.version     = '0.4.1'
   s.licenses    = ['Mozilla Public License v2.0 (https://www.mozilla.org/MPL/2.0/)']
   s.summary     = "Basic JumpCloud system configuration via api"
   s.authors     = ["Topher Marie"]

--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -7,7 +7,7 @@ class JumpCloud
   
   attr_accessor :settings
   
-  def initialize(args=self.class.get_system_data())
+  def initialize(args=self.class.get_system_data)
     @settings = args
   end
   
@@ -50,24 +50,24 @@ class JumpCloud
   end
 
   def self.set_system_tags(*tags)
-    system_data = get_system_data()
+    system_data = get_system_data
     system_data["tags"] = tags
     send_to_server(system_data)
   end
 
   def self.set_system_name(system_name)
-    system_data = get_system_data()
+    system_data = get_system_data
     system_data["displayName"] = system_name
     send_to_server(system_data)
   end
 
-  def self.set_sshPassEnabled()
-    system_data = get_system_data()
+  def self.set_sshPassEnabled
+    system_data = get_system_data
     system_data["allowSshPasswordAuthentication"] = true
     send_to_server(system_data)
   end
 
-  def self.delete_system()
+  def self.delete_system
     date = get_date
     system_key = get_key_from_config
     signature = create_signature("DELETE", date, system_key)

--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -34,7 +34,8 @@ class JumpCloud
 
   def self.get_key_from_config
     key = parse_config["systemKey"]
-    key.nil? ? fail('systemKey not found in configuration!') : key
+    fail('systemKey not found in configuration!') if key.nil?
+    key
   end
 
   def self.create_signature(verb, date, system_key)

--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -28,10 +28,13 @@ class JumpCloud
     file = '/opt/jc/jcagent.conf'
     fail file_not_found_text(file) unless File.exists?(file)
     JSON.parse(IO.read(file))
+  rescue JSON::ParserError
+    raise "Problem parsing #{file} as JSON; it is valid JSON?"
   end
 
   def self.get_key_from_config
-    parse_config["systemKey"]
+    key = parse_config["systemKey"]
+    key.nil? ? fail('systemKey not found in configuration!') : key
   end
 
   def self.create_signature(verb, date, system_key)
@@ -94,7 +97,6 @@ class JumpCloud
     request["Authorization"] = "Signature keyId=\"system/#{system_key}\",headers=\"request-line date\",algorithm=\"rsa-sha256\",signature=\"#{signature}\""
     request["Date"] = "#{date}"
     request["accept"] = "application/json"
-
     response = http.request(request)
     JSON.parse(response.body)
   end

--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -79,7 +79,7 @@ class JumpCloud
     request["Date"] = "#{date}"
     request["accept"] = "application/json"
     request["Content-Type"] = "application/json"
-    response = http.request(request)
+    http.request(request)
   end
 
   def self.get_system_data()
@@ -95,7 +95,7 @@ class JumpCloud
     request["accept"] = "application/json"
 
     response = http.request(request)
-    return JSON.parse(response.body)
+    JSON.parse(response.body)
   end
 
   def self.send_to_server(data)
@@ -111,7 +111,7 @@ class JumpCloud
     request["accept"] = "application/json"
     request["Content-Type"] = "application/json"
     request.body = JSON.generate(data)
-    response = http.request(request)
+    http.request(request)
   end
 
 end  

--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -87,7 +87,6 @@ class JumpCloud
     system_key = get_key_from_config
     signature = create_signature("GET", date, system_key)
     uri = URI.parse("https://console.jumpcloud.com/api/systems/#{system_key}")
-    request = Net::HTTP.new(uri.host, uri.port)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     request = Net::HTTP::Get.new(uri.request_uri)

--- a/lib/jumpcloud.rb
+++ b/lib/jumpcloud.rb
@@ -42,7 +42,8 @@ class JumpCloud
 
   def self.client_key
     file = '/opt/jc/client.key'
-    File.exists?(file) ? File.open(file) : fail(file_not_found_text(file))
+    fail file_not_found_text(file) unless File.exists?(file)
+    File.open(file)
   end
 
   def self.file_not_found_text(path)
@@ -82,7 +83,7 @@ class JumpCloud
     http.request(request)
   end
 
-  def self.get_system_data()
+  def self.get_system_data
     date = get_date
     system_key = get_key_from_config
     signature = create_signature("GET", date, system_key)


### PR DESCRIPTION
"Real" things:
- wrapped each of the file reads in existence checks, throwing errors if required files aren't present
- addresses #3 by specifically raising an error if `systemKey` is not present in hash that parses from `/opt/jc/jcagent.conf`

TLC-type things:
- removed parenthesis from parameterless method calls
- removed unneeded `return` statements since ruby implicitly returns the last line of a method
- removed a couple unused variables

Saw the issue on the repo and figured I could probably close it in a day :) With that in mind, these changes have been tested locally in pry and I have verified that the error handling/messaging is working as intended. I have _not_ tested these changes on a live system to talk with Jumpcloud! None of those interactions have changed but I feel it's worth stating.

Let me know if anything in here seems undesirable, I'll change as needed :) :thumbsup:
